### PR TITLE
{cosmosdb}Remove case sensitivity when removing network-rule

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/cosmosdb/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/cosmosdb/custom.py
@@ -1655,7 +1655,7 @@ def cli_cosmosdb_network_rule_remove(cmd,
     virtual_network_rules = []
     rule_removed = False
     for rule in existing.virtual_network_rules:
-        if rule.id != subnet:
+        if rule.id.lower() != subnet.lower():
             virtual_network_rules.append(
                 VirtualNetworkRule(id=rule.id,
                                    ignore_missing_v_net_service_endpoint=rule.ignore_missing_v_net_service_endpoint))


### PR DESCRIPTION
Remove case sensitivity when removing network-rule - Fix #23680

**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
az cosmosdb network-rule remove

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Remove case sensitivity for subnet id when removing network-rule

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
